### PR TITLE
  Fix compile error on 4.10

### DIFF
--- a/SensibleEditorSourceCodeAccess.uplugin
+++ b/SensibleEditorSourceCodeAccess.uplugin
@@ -5,11 +5,11 @@
 	"VersionName" : "1.0",
 	"CreatedBy" : "K. Ernest 'iFire' Lee",
 	"CreatedByURL" : "https://github.com/fire/SensibleEditorSourceCodeAccess.git",
-	"EngineVersion" : "4.3.0",
+	"EngineVersion" : "4.10",
 	"Description" : "Allows access to source code with Sensible Editor.",
 	"Category" : "Developer.Source Code Access",
 	"EnabledByDefault" : true,
-	
+
 	"Modules" :
 	[
 		{

--- a/Source/SensibleEditorSourceCodeAccess/Private/SensibleEditorSourceCodeAccessor.h
+++ b/Source/SensibleEditorSourceCodeAccess/Private/SensibleEditorSourceCodeAccessor.h
@@ -27,6 +27,7 @@ class FSensibleSourceCodeAccessor : public ISourceCodeAccessor
 {
 public:
 	/** ISourceCodeAccessor implementation */
+	virtual void RefreshAvailability() override { }
 	virtual bool CanAccessSourceCode() const override;
 	virtual FName GetFName() const override;
 	virtual FText GetNameText() const override;
@@ -35,6 +36,6 @@ public:
 	virtual bool OpenFileAtLine(const FString& FullPath, int32 LineNumber, int32 ColumnNumber = 0) override;
 	virtual bool OpenSourceFiles(const TArray<FString>& AbsoluteSourcePaths) override;
 	virtual bool SaveAllOpenDocuments() const override;
-    virtual bool AddSourceFiles(const TArray<FString>& AbsoluteSourcePaths, const TArray<FString>& AvailableModules) override;
+	virtual bool AddSourceFiles(const TArray<FString>& AbsoluteSourcePaths, const TArray<FString>& AvailableModules) override;
 	virtual void Tick(const float DeltaTime) override;
 };


### PR DESCRIPTION
When compiling UE4Editor v4.10, I get the following error:

```
[601/792] Compile Module.SensibleEditorSourceCodeAccess.cpp
In file included from /mnt/data/home/caleb/Downloads/UnrealEngineTest/Engine/Plugins/Developer/SensibleEditorSourceCodeAccess/Intermediate/Build/Linux/x86_64-unknown-linux-gnu/UE4Editor/Development/SensibleEditorSourceCodeAccess/Module.SensibleEditorSourceCodeAccess.cpp:2:
In file included from /mnt/data/home/caleb/Downloads/UnrealEngineTest/Engine/Plugins/Developer/SensibleEditorSourceCodeAccess/Source/SensibleEditorSourceCodeAccess/Private/SensibleEditorSourceCodeAccessModule.cpp:24:
/mnt/data/home/caleb/Downloads/UnrealEngineTest/Engine/Plugins/Developer/SensibleEditorSourceCodeAccess/Source/SensibleEditorSourceCodeAccess/Private/SensibleEditorSourceCodeAccessModule.h:35:33: error: field type 'FSensibleSourceCodeAccessor' is an abstract class
    FSensibleSourceCodeAccessor SensibleEditorSourceCodeAccessor;
                                ^
Developer/SourceCodeAccess/Public/ISourceCodeAccessor.h:18:15: note: unimplemented pure virtual method 'RefreshAvailability' in 'FSensibleSourceCodeAccessor'
        virtual void RefreshAvailability() = 0;
                     ^
In file included from /mnt/data/home/caleb/Downloads/UnrealEngineTest/Engine/Plugins/Developer/SensibleEditorSourceCodeAccess/Intermediate/Build/Linux/x86_64-unknown-linux-gnu/UE4Editor/Development/SensibleEditorSourceCodeAccess/Module.SensibleEditorSourceCodeAccess.cpp:2:
/mnt/data/home/caleb/Downloads/UnrealEngineTest/Engine/Plugins/Developer/SensibleEditorSourceCodeAccess/Source/SensibleEditorSourceCodeAccess/Private/SensibleEditorSourceCodeAccessModule.cpp:26:1: error: cannot initialize return object of type 'IModuleInterface *' with an rvalue of type 'FSensibleSourceCodeAccessModule *'
IMPLEMENT_MODULE( FSensibleSourceCodeAccessModule, SensibleEditorSourceCodeAccess );
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Runtime/Core/Public/Modules/ModuleManager.h:683:11: note: expanded from macro 'IMPLEMENT_MODULE'
                        return new ModuleImplClass(); \
                               ^~~~~~~~~~~~~~~~~~~~~
```

`ISourceCodeAccessor` appears to have a new unimplemented virtual method:

```cpp
virtual void RefreshAvailability() = 0;
```

The `NullSourceCodeAccess` implementation simply defines the method as:

```cpp
virtual void RefreshAvailability() override { }
```

Adding this method to `FSensibleSourceCodeAccessor` fixes the issue, and compiles properly. NOTE: This fix will likely cause SensibleEditorSourceCodeAccess to fail to compile on earlier versions of UE4Editor because the new method is overridden.