### PR TITLE
reorder headers in order to fix build errors on clang-3.9.1/ue-14.5.0

### DIFF
--- a/SensibleEditorSourceCodeAccess.uplugin
+++ b/SensibleEditorSourceCodeAccess.uplugin
@@ -5,7 +5,7 @@
 	"VersionName" : "1.0",
 	"CreatedBy" : "K. Ernest 'iFire' Lee",
 	"CreatedByURL" : "https://github.com/fire/SensibleEditorSourceCodeAccess.git",
-	"EngineVersion" : "4.10",
+	"EngineVersion" : "4.16",
 	"Description" : "Allows access to source code with Sensible Editor.",
 	"Category" : "Developer.Source Code Access",
 	"EnabledByDefault" : true,

--- a/Source/SensibleEditorSourceCodeAccess/Private/SensibleEditorSourceCodeAccessModule.cpp
+++ b/Source/SensibleEditorSourceCodeAccess/Private/SensibleEditorSourceCodeAccessModule.cpp
@@ -19,9 +19,9 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
+#include "SensibleEditorSourceCodeAccessModule.h"
 #include "SensibleEditorSourceCodeAccessPrivatePCH.h"
 #include "Runtime/Core/Public/Features/IModularFeatures.h"
-#include "SensibleEditorSourceCodeAccessModule.h"
 
 IMPLEMENT_MODULE( FSensibleSourceCodeAccessModule, SensibleEditorSourceCodeAccess );
 

--- a/Source/SensibleEditorSourceCodeAccess/Private/SensibleEditorSourceCodeAccessor.cpp
+++ b/Source/SensibleEditorSourceCodeAccess/Private/SensibleEditorSourceCodeAccessor.cpp
@@ -19,8 +19,8 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
-#include "SensibleEditorSourceCodeAccessPrivatePCH.h"
 #include "SensibleEditorSourceCodeAccessor.h"
+#include "SensibleEditorSourceCodeAccessPrivatePCH.h"
 #include "DesktopPlatformModule.h"
 
 #define LOCTEXT_NAMESPACE "SensibleEditorSourceCodeAccessor"

--- a/Source/SensibleEditorSourceCodeAccess/Private/SensibleEditorSourceCodeAccessor.cpp
+++ b/Source/SensibleEditorSourceCodeAccess/Private/SensibleEditorSourceCodeAccessor.cpp
@@ -22,6 +22,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include "SensibleEditorSourceCodeAccessor.h"
 #include "SensibleEditorSourceCodeAccessPrivatePCH.h"
 #include "DesktopPlatformModule.h"
+#include <cstdlib>
 
 #define LOCTEXT_NAMESPACE "SensibleEditorSourceCodeAccessor"
 
@@ -56,7 +57,12 @@ bool FSensibleSourceCodeAccessor::OpenSolution()
         // Add this to handle spaces in path names.
         const FString NewFullPath = FString::Printf(TEXT("\"%s\""), *FullPath);
 
-        FString Editor = FString(TEXT("/usr/bin/sensible-editor"));
+        FString Editor = FString(UTF8_TO_TCHAR(std::getenv("EDITOR")));
+        if (Editor.IsEmpty())
+        {
+            Editor = FString(TEXT("/usr/bin/sensible-editor"));
+        }
+
         if(FLinuxPlatformProcess::CreateProc(*Editor,
                                              *NewFullPath,
                                              true,
@@ -76,7 +82,11 @@ bool FSensibleSourceCodeAccessor::OpenSolution()
 
 bool FSensibleSourceCodeAccessor::OpenFileAtLine(const FString& FullPath, int32 LineNumber, int32 ColumnNumber)
 {
-    FString Editor = FString(TEXT("/usr/bin/sensible-editor"));
+    FString Editor = FString(UTF8_TO_TCHAR(std::getenv("EDITOR")));
+    if (Editor.IsEmpty())
+    {
+        Editor = FString(TEXT("/usr/bin/sensible-editor"));
+    }
 
     // Add this to handle spaces in path names.
     const FString NewFullPath = FString::Printf(TEXT("\"%s+%d\""), *FullPath, LineNumber);
@@ -101,7 +111,11 @@ bool FSensibleSourceCodeAccessor::OpenSourceFiles(const TArray<FString>& Absolut
 {
   for ( const FString& SourcePath : AbsoluteSourcePaths ) 
   {
-    FString Editor = FString(TEXT("/usr/bin/sensible-editor"));
+    FString Editor = FString(UTF8_TO_TCHAR(std::getenv("EDITOR")));
+    if (Editor.IsEmpty())
+    {
+        Editor = FString(TEXT("/usr/bin/sensible-editor"));
+    }
 
     // Add this to handle spaces in path names.
     const FString NewSourcePath = FString::Printf(TEXT("\"%s\""), *SourcePath);

--- a/Source/SensibleEditorSourceCodeAccess/SensibleEditorSourceCodeAccess.Build.cs
+++ b/Source/SensibleEditorSourceCodeAccess/SensibleEditorSourceCodeAccess.Build.cs
@@ -23,7 +23,7 @@ namespace UnrealBuildTool.Rules
 {
 	public class SensibleEditorSourceCodeAccess : ModuleRules
 	{
-                 public SensibleEditorSourceCodeAccess(TargetInfo Target)
+                 public SensibleEditorSourceCodeAccess(ReadOnlyTargetRules Target) : base(Target)
 		 {
 		 	PrivateDependencyModuleNames.AddRange(
                                 new string[]


### PR DESCRIPTION
I get a bunch of errors like this:

```
/opt/UnrealEngine/Engine/Plugins/Developer/QtCreatorSourceCodeAccess/Source/QtCreatorSourceCodeAccess/Private/QtCreatorSourceCodeAccessor.cpp(1): error: Expected QtCreatorSourceCodeAccessor.h to be first header included.
/opt/UnrealEngine/Engine/Plugins/Developer/SensibleEditorSourceCodeAccess/Source/SensibleEditorSourceCodeAccess/Private/SensibleEditorSourceCodeAccessModule.cpp(1): error: Expected SensibleEditorSourceCodeAccessModule.h to be first header included.
/opt/UnrealEngine/Engine/Plugins/Developer/SensibleEditorSourceCodeAccess/Source/SensibleEditorSourceCodeAccess/Private/SensibleEditorSourceCodeAccessor.cpp(1): error: Expected SensibleEditorSourceCodeAccessor.h to be first header included.
Build canceled.
```

And if I reorder the headers as the error says it builds just fine.