### PR TITLE
read EDITOR env var before running sensible-editor to make the plugin…

### DIFF
--- a/Source/SensibleEditorSourceCodeAccess/Private/SensibleEditorSourceCodeAccessor.cpp
+++ b/Source/SensibleEditorSourceCodeAccess/Private/SensibleEditorSourceCodeAccessor.cpp
@@ -22,6 +22,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #include "SensibleEditorSourceCodeAccessPrivatePCH.h"
 #include "SensibleEditorSourceCodeAccessor.h"
 #include "DesktopPlatformModule.h"
+#include <cstdlib>
 
 #define LOCTEXT_NAMESPACE "SensibleEditorSourceCodeAccessor"
 
@@ -56,7 +57,12 @@ bool FSensibleSourceCodeAccessor::OpenSolution()
         // Add this to handle spaces in path names.
         const FString NewFullPath = FString::Printf(TEXT("\"%s\""), *FullPath);
 
-        FString Editor = FString(TEXT("/usr/bin/sensible-editor"));
+        FString Editor = FString(UTF8_TO_TCHAR(std::getenv("EDITOR")));
+        if (Editor.IsEmpty())
+        {
+            Editor = FString(TEXT("/usr/bin/sensible-editor"));
+        }
+
         if(FLinuxPlatformProcess::CreateProc(*Editor,
                                              *NewFullPath,
                                              true,
@@ -76,7 +82,11 @@ bool FSensibleSourceCodeAccessor::OpenSolution()
 
 bool FSensibleSourceCodeAccessor::OpenFileAtLine(const FString& FullPath, int32 LineNumber, int32 ColumnNumber)
 {
-    FString Editor = FString(TEXT("/usr/bin/sensible-editor"));
+    FString Editor = FString(UTF8_TO_TCHAR(std::getenv("EDITOR")));
+    if (Editor.IsEmpty())
+    {
+        Editor = FString(TEXT("/usr/bin/sensible-editor"));
+    }
 
     // Add this to handle spaces in path names.
     const FString NewFullPath = FString::Printf(TEXT("\"%s+%d\""), *FullPath, LineNumber);
@@ -101,7 +111,11 @@ bool FSensibleSourceCodeAccessor::OpenSourceFiles(const TArray<FString>& Absolut
 {
   for ( const FString& SourcePath : AbsoluteSourcePaths ) 
   {
-    FString Editor = FString(TEXT("/usr/bin/sensible-editor"));
+    FString Editor = FString(UTF8_TO_TCHAR(std::getenv("EDITOR")));
+    if (Editor.IsEmpty())
+    {
+        Editor = FString(TEXT("/usr/bin/sensible-editor"));
+    }
 
     // Add this to handle spaces in path names.
     const FString NewSourcePath = FString::Printf(TEXT("\"%s\""), *SourcePath);


### PR DESCRIPTION
read EDITOR env var before running sensible-editor to make the plugin work on non-debian derivative distros

I'm using Funtoo (a Gentoo derivative) and the plugin won't work on my distro. So, I modified the code to read the EDITOR environment variable before running sensible-editor.

For more info on why sensible-editor is a fallback and should be read when $EDITOR is not available see the following answer:
see http://superuser.com/a/168710