### PR TITLE
make the plugin build and work with UE 4.16.x

### DIFF
--- a/SensibleEditorSourceCodeAccess.uplugin
+++ b/SensibleEditorSourceCodeAccess.uplugin
@@ -5,7 +5,7 @@
 	"VersionName" : "1.0",
 	"CreatedBy" : "K. Ernest 'iFire' Lee",
 	"CreatedByURL" : "https://github.com/fire/SensibleEditorSourceCodeAccess.git",
-	"EngineVersion" : "4.10",
+	"EngineVersion" : "4.16",
 	"Description" : "Allows access to source code with Sensible Editor.",
 	"Category" : "Developer.Source Code Access",
 	"EnabledByDefault" : true,

--- a/Source/SensibleEditorSourceCodeAccess/SensibleEditorSourceCodeAccess.Build.cs
+++ b/Source/SensibleEditorSourceCodeAccess/SensibleEditorSourceCodeAccess.Build.cs
@@ -23,7 +23,7 @@ namespace UnrealBuildTool.Rules
 {
 	public class SensibleEditorSourceCodeAccess : ModuleRules
 	{
-                 public SensibleEditorSourceCodeAccess(TargetInfo Target)
+                 public SensibleEditorSourceCodeAccess(ReadOnlyTargetRules Target) : base(Target)
 		 {
 		 	PrivateDependencyModuleNames.AddRange(
                                 new string[]


### PR DESCRIPTION
The plugin fails to build on UE 4.16.x. Furthermore, on UE 4.16.x it keeps asking to enable/disable the plugin at each startup. This pull request solve those issues.

Please note that this pull request requires pull request #14 