### PR TITLE
make the plugin build and work with UE 4.20.2

### DIFF
--- a/Source/SensibleEditorSourceCodeAccess/Private/SensibleEditorSourceCodeAccessPrivatePCH.h
+++ b/Source/SensibleEditorSourceCodeAccess/Private/SensibleEditorSourceCodeAccessPrivatePCH.h
@@ -22,5 +22,5 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 #pragma once
 
 #include "Core.h"
-#include "ModuleManager.h"
+#include "Modules/ModuleManager.h"
 #include "ISourceCodeAccessModule.h"


### PR DESCRIPTION
In Unreal Engine 4.20.2 (against which I tested the build of this plugin), the `ModuleManager.h` header file is located in the `Modules` directory in the include path, and that's why it should be included as `Modules/ModuleManager.h`.  Otherwise the build of the `UE4Editor` target would fail (because of the `Module.SensibleEditorSourceCodeAccess.cpp` object).